### PR TITLE
fix: increase max_allowed_packet for mysql

### DIFF
--- a/global/docker-compose.yml
+++ b/global/docker-compose.yml
@@ -25,6 +25,7 @@ services:
 
   mysql:
     image: mysql:5.7
+    command: --max_allowed_packet=1073741824
     volumes:
       - "mysqlData:/var/lib/mysql"
     ports:


### PR DESCRIPTION
Increase max allowed packet to 1GB for Mysql Container, TOH DB is getting too big for current local setup.